### PR TITLE
Do not require patch versions unless it is relay necessary

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,9 @@
         }
     ],
     "require": {
-        "php": "^7.4.4",
-        "livewire/livewire": "^2.2.6",
-        "blade-ui-kit/blade-icons": "^0.4.5",
+        "php": "^7.4.0",
+        "livewire/livewire": "^2.2.0",
+        "blade-ui-kit/blade-icons": "^0.4.0",
         "laravel/framework": "^7.0|^8.0"
     },
     "autoload": {


### PR DESCRIPTION
Even Ubuntu 20.04 LTS has php 7.4.3 at the moment, so this composer json blocks the installing process (or you have to use --ignore-platform-reqs). As patch versions should not bring new features but only solve bugs and security things, it is unlikely that the patch version is important. (See https://semver.org)